### PR TITLE
Websocket connection support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,11 +87,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
 ]
 
 [[package]]
@@ -119,6 +125,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bimap"
@@ -169,6 +181,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
@@ -252,6 +270,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -355,6 +382,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "flate2"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "libz-sys",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +473,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
+dependencies = [
+ "futures-io",
+ "rustls",
+ "webpki",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +515,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -570,6 +621,12 @@ dependencies = [
  "match_cfg",
  "winapi",
 ]
+
+[[package]]
+name = "httparse"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "idna"
@@ -682,7 +739,7 @@ version = "0.39.0"
 source = "git+https://github.com/comit-network/rust-libp2p.git?branch=rendezvous#4af8af780ba3b1c8344b3d19a146d9628ad5bdb2"
 dependencies = [
  "atomic",
- "bytes",
+ "bytes 1.0.1",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -694,6 +751,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-swarm-derive",
  "libp2p-tcp",
+ "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
  "parking_lot",
@@ -753,7 +811,7 @@ version = "0.29.0"
 source = "git+https://github.com/comit-network/rust-libp2p.git?branch=rendezvous#4af8af780ba3b1c8344b3d19a146d9628ad5bdb2"
 dependencies = [
  "asynchronous-codec",
- "bytes",
+ "bytes 1.0.1",
  "futures",
  "libp2p-core",
  "log",
@@ -769,7 +827,7 @@ name = "libp2p-noise"
 version = "0.32.0"
 source = "git+https://github.com/comit-network/rust-libp2p.git?branch=rendezvous#4af8af780ba3b1c8344b3d19a146d9628ad5bdb2"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "curve25519-dalek",
  "futures",
  "lazy_static",
@@ -862,6 +920,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-websocket"
+version = "0.30.0"
+source = "git+https://github.com/comit-network/rust-libp2p.git?branch=rendezvous#4af8af780ba3b1c8344b3d19a146d9628ad5bdb2"
+dependencies = [
+ "either",
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "log",
+ "quicksink",
+ "rw-stream-sink",
+ "soketto",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "libp2p-yamux"
 version = "0.33.0"
 source = "git+https://github.com/comit-network/rust-libp2p.git?branch=rendezvous#4af8af780ba3b1c8344b3d19a146d9628ad5bdb2"
@@ -880,7 +955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.12.3",
  "digest",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -919,6 +994,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76acb433e21d10f5f9892b1962c2856c58c7f39a9e4bd68ac82b9436a0ffd5b9"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -980,6 +1066,16 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -1059,7 +1155,7 @@ name = "multistream-select"
 version = "0.10.3"
 source = "git+https://github.com/comit-network/rust-libp2p.git?branch=rendezvous#4af8af780ba3b1c8344b3d19a146d9628ad5bdb2"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures",
  "log",
  "pin-project 1.0.7",
@@ -1215,6 +1311,12 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
+
+[[package]]
+name = "pin-project-lite"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
@@ -1224,6 +1326,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "poly1305"
@@ -1315,7 +1423,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "prost-derive",
 ]
 
@@ -1325,7 +1433,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "heck",
  "itertools",
  "log",
@@ -1356,7 +1464,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "prost",
 ]
 
@@ -1365,6 +1473,17 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quicksink"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77de3c815e5a160b1539c6592796801df2043ae35e123b46d73380cfa57af858"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite 0.1.12",
+]
 
 [[package]]
 name = "quote"
@@ -1547,6 +1666,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.0",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1700,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -1616,6 +1758,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1704,6 +1859,22 @@ checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "soketto"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
+dependencies = [
+ "base64 0.12.3",
+ "bytes 0.5.6",
+ "flate2",
+ "futures",
+ "httparse",
+ "log",
+ "rand 0.7.3",
+ "sha-1",
 ]
 
 [[package]]
@@ -1845,13 +2016,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
- "bytes",
+ "bytes 1.0.1",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "signal-hook-registry",
  "tokio-macros",
  "winapi",
@@ -1884,7 +2055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if",
- "pin-project-lite",
+ "pin-project-lite 0.2.6",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2067,7 +2238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
 dependencies = [
  "asynchronous-codec",
- "bytes",
+ "bytes 1.0.1",
 ]
 
 [[package]]
@@ -2096,6 +2267,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2210,6 +2387,25 @@ checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1"
 atty = "0.2"
 futures = { version = "0.3", default-features = false }
-libp2p = { git = "https://github.com/comit-network/rust-libp2p.git", branch = "rendezvous", default-features = false, features = [ "rendezvous", "tcp-tokio", "yamux", "mplex", "dns-tokio", "noise", "ping" ] }
+libp2p = { git = "https://github.com/comit-network/rust-libp2p.git", branch = "rendezvous", default-features = false, features = [ "rendezvous", "tcp-tokio", "yamux", "mplex", "dns-tokio", "noise", "ping", "websocket" ] }
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", features = [ "rt-multi-thread", "time", "macros", "sync", "process", "fs", "net", "io-util" ] }
 tracing = { version = "0.1", features = [ "attributes" ] }

--- a/README.md
+++ b/README.md
@@ -11,3 +11,33 @@ rendezvous_server --secret-file <PATH-TO-SECRET-FILE> --port 8888
 ```
 
 Run `rendezvous_server --help` for more options
+
+### TLS configuration
+
+You can test with self signed certificates using `openssl`:
+
+1. Create certificate:
+
+```bash
+# generate pass key to be used for generating private key
+openssl genrsa -aes256 -passout pass:gsahdg -out server.pass.key 4096
+# generate private key
+openssl rsa -passin pass:gsahdg -in server.pass.key -out server.key
+# remove pass key
+rm server.pass.key
+
+# create certificate signing request
+openssl req -new -key server.key -out server.csr
+
+# create self signed certificate from private key and signing request
+openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt
+```
+
+2. Convert certificate to `der` format to be compatible with libp2p's TlsConfig:
+
+```bash
+# convert private key to der
+openssl rsa -inform pem -in server.key -outform der -out server_pk.der
+# convert certificate to der
+openssl x509 -inform pem -in server.crt -outform der -out server_cert.der
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use futures::{AsyncRead, AsyncWrite, StreamExt};
 use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::Boxed;
@@ -12,7 +12,8 @@ use libp2p::rendezvous::{Config, Event as RendezvousEvent, Rendezvous};
 use libp2p::swarm::toggle::Toggle;
 use libp2p::swarm::{SwarmBuilder, SwarmEvent};
 use libp2p::tcp::TokioTcpConfig;
-use libp2p::websocket::WsConfig;
+use libp2p::websocket::tls::{Certificate, PrivateKey};
+use libp2p::websocket::{tls, WsConfig};
 use libp2p::yamux::YamuxConfig;
 use libp2p::{identity, noise, rendezvous, Multiaddr, PeerId, Swarm, Transport};
 use std::fmt;
@@ -36,16 +37,19 @@ struct Cli {
     /// --secret-file argument
     #[structopt(long)]
     generate_secret: bool,
+
     /// Port used for listening on TCP (default)
     #[structopt(long)]
     listen_tcp: u16,
     /// Format logs as JSON
     #[structopt(long)]
     json: bool,
+
     /// Don't include timestamp in logs. Useful if captured logs already get
     /// timestamped, e.g. through journald.
     #[structopt(long)]
     no_timestamp: bool,
+
     /// Compose the ping behaviour together with the rendezvous behaviour in
     /// case a rendezvous server with Ping is required. This feature will be removed once https://github.com/libp2p/rust-libp2p/issues/2109 is fixed.
     #[structopt(long)]
@@ -53,6 +57,15 @@ struct Cli {
     /// Port used for listening on websocket
     #[structopt(long)]
     listen_websocket: Option<u16>,
+
+    /// Path to server private key for secure websocket connection
+    /// configuration.
+    #[structopt(long)]
+    tls_private_key: Option<PathBuf>,
+    /// Path to server SSL certificate for secure websocket connection
+    /// configuration.
+    #[structopt(long)]
+    tls_certificate: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -72,7 +85,21 @@ async fn main() -> Result<()> {
     };
     let identity = identity::Keypair::Ed25519(secret_key.into());
 
-    let mut swarm = create_swarm(identity, cli.ping, cli.listen_websocket.is_some())?;
+    let tls_config = tls_config_from_params(
+        cli.tls_private_key,
+        cli.tls_certificate,
+        cli.listen_websocket.is_some(),
+    )
+    .await?;
+
+    let ws_or_wss = if tls_config.is_some() { "wss" } else { "ws" };
+
+    let mut swarm = create_swarm(
+        identity,
+        cli.ping,
+        cli.listen_websocket.is_some(),
+        tls_config,
+    )?;
 
     tracing::info!(peer_id=%swarm.local_peer_id(), "Rendezvous server peer id");
 
@@ -87,7 +114,7 @@ async fn main() -> Result<()> {
     if let Some(websocket_port) = cli.listen_websocket {
         swarm
             .listen_on(
-                format!("/ip4/0.0.0.0/tcp/{}/ws", websocket_port)
+                format!("/ip4/0.0.0.0/tcp/{}/{}", websocket_port, ws_or_wss)
                     .parse()
                     .unwrap(),
             )
@@ -132,6 +159,29 @@ async fn main() -> Result<()> {
             _ => {}
         }
     }
+}
+
+async fn tls_config_from_params(
+    private_key: Option<PathBuf>,
+    certificate: Option<PathBuf>,
+    websocket: bool,
+) -> Result<Option<tls::Config>> {
+    let (pk, cert) = match (private_key, certificate) {
+        (None, None) => return Ok(None),
+        (Some(pk), Some(cert)) => (pk, cert),
+        _ => bail!("Server private key and certificate both have to be provided"),
+    };
+    if !websocket {
+        tracing::warn!("The provided SSL parameters won't have any affect, because you did not activate websockets");
+        return Ok(None);
+    }
+    let pk = fs::read(pk).await?;
+    let cert = fs::read(cert).await?;
+    let pk = PrivateKey::new(pk);
+    let cert = Certificate::new(cert);
+    let tls_config = tls::Config::new(pk, vec![cert])?;
+
+    Ok(Some(tls_config))
 }
 
 fn init_tracing(level: LevelFilter, json_format: bool, no_timestamp: bool) {
@@ -199,10 +249,12 @@ fn create_swarm(
     identity: identity::Keypair,
     ping: bool,
     websocket: bool,
+    tls: Option<tls::Config>,
 ) -> Result<Swarm<Behaviour>> {
     let local_peer_id = identity.public().into_peer_id();
 
-    let transport = create_transport(&identity, websocket).context("Failed to create transport")?;
+    let transport =
+        create_transport(&identity, websocket, tls).context("Failed to create transport")?;
     let rendezvous = Rendezvous::new(identity, Config::default());
     let swarm = SwarmBuilder::new(transport, Behaviour::new(rendezvous, ping), local_peer_id)
         .executor(Box::new(|f| {
@@ -216,11 +268,17 @@ fn create_swarm(
 fn create_transport(
     identity: &identity::Keypair,
     websocket: bool,
+    tls: Option<tls::Config>,
 ) -> Result<Boxed<(PeerId, StreamMuxerBox)>> {
     let tcp_with_dns = TokioDnsConfig::system(TokioTcpConfig::new().nodelay(true)).unwrap();
 
     let transport = if websocket {
-        let websocket_with_dns = WsConfig::new(tcp_with_dns.clone());
+        let mut websocket_with_dns = WsConfig::new(tcp_with_dns.clone());
+
+        if let Some(tls) = tls {
+            websocket_with_dns.set_tls_config(tls);
+        }
+
         authenticate_and_multiplex(
             tcp_with_dns.or_transport(websocket_with_dns).boxed(),
             &identity,


### PR DESCRIPTION
Fixes comit-network/waves#176

Websocket connection support, so we can discover from browser.
TLS config is still missing, but I think we can merge this as working WS example and I'll open a followup for WSS with the TLS configuration. 

Note: The first commit makes the `Ping` behaviour toggleable so we can run a rendezvous server that does not compose it. (It is only a requirement for the ASB-CLI setup in XMR<>BTC and because of the way Ping is written in rust, see: https://github.com/libp2p/rust-libp2p/issues/2109 )